### PR TITLE
fix reader not loading when the file was sent content-encoding gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - When playback is paused, but the sleep timer is active, shaking does now not reset the sleep timer anymore.
+- Fixed an issue where the reader would not load when a file was sent using compression (Thanks to @Garrett3Nelson for helping)
 
 ## 1.4.9
 

--- a/lib/screens/reader/reader_builders.dart
+++ b/lib/screens/reader/reader_builders.dart
@@ -220,13 +220,7 @@ extension _ReaderBuilders on _ReaderState {
             ),
           );
           request.response.statusCode = response.statusCode ?? 200;
-          final ignoreHeaders = {
-            'content-length',
-            'content-encoding',
-            'transfer-encoding',
-            'connection',
-            'host',
-          };
+          final ignoreHeaders = {'content-length', 'content-encoding', 'transfer-encoding', 'connection', 'host'};
           response.headers.forEach((key, values) {
             if (ignoreHeaders.contains(key.toLowerCase())) return;
             for (final value in values) {

--- a/lib/screens/reader/reader_builders.dart
+++ b/lib/screens/reader/reader_builders.dart
@@ -208,27 +208,43 @@ extension _ReaderBuilders on _ReaderState {
       onRelocated: _onEpubRelocated,
       onTtsJumpToSentence: _jumpToTtsSentence,
       bookFetcher: (url, headers, request) async {
-        final api = ref.read(absApiProvider);
-        final dio = api?.dio ?? Dio();
-        final response = await dio.get<ResponseBody>(
-          url,
-          options: Options(
-            headers: headers,
-            responseType: ResponseType.stream,
-            extra: <String, dynamic>{'doNotCache': true},
-          ),
-        );
-        request.response.statusCode = response.statusCode ?? 200;
-        response.headers.forEach((key, values) {
-          for (final value in values) {
-            request.response.headers.add(key, value);
+        try {
+          final api = ref.read(absApiProvider);
+          final dio = api?.dio ?? Dio();
+          final response = await dio.get<ResponseBody>(
+            url,
+            options: Options(
+              headers: headers,
+              responseType: ResponseType.stream,
+              extra: <String, dynamic>{'doNotCache': true},
+            ),
+          );
+          request.response.statusCode = response.statusCode ?? 200;
+          final ignoreHeaders = {
+            'content-length',
+            'content-encoding',
+            'transfer-encoding',
+            'connection',
+            'host',
+          };
+          response.headers.forEach((key, values) {
+            if (ignoreHeaders.contains(key.toLowerCase())) return;
+            for (final value in values) {
+              request.response.headers.add(key, value);
+            }
+          });
+          request.response.headers.set('Access-Control-Allow-Origin', '*');
+          final data = response.data;
+          if (data != null) {
+            await data.stream.cast<List<int>>().pipe(request.response);
+          } else {
+            await request.response.close();
           }
-        });
-        request.response.headers.set('Access-Control-Allow-Origin', '*');
-        final data = response.data;
-        if (data != null) {
-          await data.stream.cast<List<int>>().pipe(request.response);
-        } else {
+        } catch (e) {
+          logger('bookFetcher error fetching $url: $e', tag: 'EpubReader', level: InfoLevel.error);
+          request.response.statusCode = 500;
+          request.response.headers.set('Access-Control-Allow-Origin', '*');
+          request.response.write('Internal Server Error: $e');
           await request.response.close();
         }
       },


### PR DESCRIPTION
## Summary

Fixed an issue where the reader would not load when a file was sent using compression (Thanks to @Garrett3Nelson for helping)

## Platforms Affected

<!-- The selected platforms are built and tested by CI. Select all platforms affected by this PR. Keep the checkbox labels unchanged so CI can parse them. You can check the box with [x] or leave it unchecked with [ ]. -->

- [x] Linux
- [ ] Windows
- [ ] Android (and Android Auto)
- [ ] iOS
- [ ] macOS
- [ ] Android Automotive

## Additional Notes

<!-- Add reviewer context, screenshots, migration notes, or follow-up tasks. -->
