### PR TITLE
Fix cold app start race conditions (needs testing on AAOS. Pre merged for now)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -240,21 +240,11 @@ jobs:
       - name: Build Android Auto debug APK
         run: flutter build apk --flavor auto --debug
 
-      - name: Build Android Auto release APK
-        run: flutter build apk --flavor auto --release
-
       - name: Upload Android Auto APK
         uses: actions/upload-artifact@v7
         with:
           name: android-auto-debug-apk
           path: build/app/outputs/flutter-apk/app-auto-debug.apk
-          retention-days: 1
-
-      - name: Upload Android Auto release APK
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-auto-release-apk
-          path: build/app/outputs/flutter-apk/app-auto-release.apk
           retention-days: 1
 
   build-android-automotive:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -240,11 +240,21 @@ jobs:
       - name: Build Android Auto debug APK
         run: flutter build apk --flavor auto --debug
 
+      - name: Build Android Auto release APK
+        run: flutter build apk --flavor auto --release
+
       - name: Upload Android Auto APK
         uses: actions/upload-artifact@v7
         with:
           name: android-auto-debug-apk
-          path: build/app/outputs/flutter-apk/*.apk
+          path: build/app/outputs/flutter-apk/app-auto-debug.apk
+          retention-days: 1
+
+      - name: Upload Android Auto release APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-auto-release-apk
+          path: build/app/outputs/flutter-apk/app-auto-release.apk
           retention-days: 1
 
   build-android-automotive:

--- a/lib/util/audio_handler/bg_audio_handler.dart
+++ b/lib/util/audio_handler/bg_audio_handler.dart
@@ -164,6 +164,12 @@ class BGAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
   final BehaviorSubject<bool> _castControlActiveSubject = BehaviorSubject<bool>.seeded(false);
   String? _castControlledContentId;
   int _castControlledTrackIndex = 0;
+  bool _hasObservedActiveUserId = false;
+  String? _observedActiveUserId;
+  Future<void>? _lastPlayedMiniPlayerRestoreFuture;
+  String? _lastPlayedMiniPlayerRestoreUserId;
+  int _lastPlayedMiniPlayerRestoreGeneration = 0;
+  int? _lastPlayedMiniPlayerRestoreActiveGeneration;
   MediaItem? _restoredMediaItem;
   Duration _restoredPosition = Duration.zero;
   BehaviorSubject<InternalMedia?> mediaItemStream = BehaviorSubject<InternalMedia?>();
@@ -643,6 +649,14 @@ class BGAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
 
     QueueItem? nextItem = nextEntry?.item;
 
+    if (nextEntry == null && _restoredMediaItem != null) {
+      final resumed = await _playLastPlayedInternal(requireStartupSettingEnabled: false, resumeCurrentIfPaused: false);
+      if (!resumed) {
+        _setQueueTransitionLoading(false);
+      }
+      return Future.value();
+    }
+
     if (nextItem == null && _lastQueueItem != null) {
       // e.g. Android still shows the notification and allows pressing play. This will re-use the last item.
       nextItem = _lastQueueItem;
@@ -1077,16 +1091,11 @@ class BGAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
             return;
           }
 
-          if (_currentMediaItem != null || queueList.isNotEmpty || _queueTransitionLoading) {
-            unawaited(stop(clearQueue: true));
-          }
+          final isInitialUser = !_hasObservedActiveUserId;
+          _hasObservedActiveUserId = true;
+          _observedActiveUserId = activeUserId;
 
-          _lastQueueItem = null;
-          _setLastPlayedMiniPlayerSnapshot(null);
-
-          // Clear Android Auto auth error as soon as login becomes active.
-          unawaited(_androidAutoClearAuthenticationRequiredState(this, refreshBrowseRoots: true));
-          unawaited(_restoreLastPlayedMiniPlayerIfEnabledInternal(explicitUserId: activeUserId));
+          unawaited(_handleActiveUserIdEmission(activeUserId, stopPlayback: !isInitialUser));
         });
 
     _showLastPlayedMiniPlayerSettingSubscription = _ref

--- a/lib/util/audio_handler/bg_audio_handler_resume.dart
+++ b/lib/util/audio_handler/bg_audio_handler_resume.dart
@@ -119,23 +119,79 @@ extension _BGAudioHandlerResume on BGAudioHandler {
     return _playLastPlayedInternal(requireStartupSettingEnabled: true, resumeCurrentIfPaused: false);
   }
 
-  Future<void> _restoreLastPlayedMiniPlayerIfEnabledInternal({String? explicitUserId}) async {
-    if (_currentMediaItem != null || _queueTransitionLoading) {
+  Future<void> _handleActiveUserIdEmission(String activeUserId, {required bool stopPlayback}) async {
+    if (stopPlayback) {
+      _lastPlayedMiniPlayerRestoreGeneration += 1;
+    }
+
+    if (stopPlayback && (_currentMediaItem != null || queueList.isNotEmpty || _queueTransitionLoading)) {
+      await stop(clearQueue: true);
+    }
+
+    if (_isDisposing || _observedActiveUserId != activeUserId) {
       return;
     }
 
-    _setLastPlayedMiniPlayerSnapshot(null);
+    if (stopPlayback) {
+      _lastQueueItem = null;
+      _restoredMediaItem = null;
+      _restoredPosition = Duration.zero;
+      _setLastPlayedMiniPlayerSnapshot(null);
+    }
 
-    final lastPlayedItem = await _readLastPlayedQueueItemForActiveUser(explicitUserId: explicitUserId);
+    // Clear Android Auto auth error as soon as login becomes active.
+    unawaited(_androidAutoClearAuthenticationRequiredState(this, refreshBrowseRoots: true));
+    await _restoreLastPlayedMiniPlayerIfEnabledInternal(explicitUserId: activeUserId);
+  }
+
+  Future<void> _restoreLastPlayedMiniPlayerIfEnabledInternal({String? explicitUserId}) async {
+    final userId = await _readActiveUserId(explicitUserId: explicitUserId);
+    if (userId == null || userId.isEmpty || _currentMediaItem != null || _queueTransitionLoading) {
+      return;
+    }
+
+    final activeRestore = _lastPlayedMiniPlayerRestoreFuture;
+    if (activeRestore != null &&
+        _lastPlayedMiniPlayerRestoreUserId == userId &&
+        _lastPlayedMiniPlayerRestoreActiveGeneration == _lastPlayedMiniPlayerRestoreGeneration) {
+      await activeRestore;
+      return;
+    }
+
+    final generation = ++_lastPlayedMiniPlayerRestoreGeneration;
+    final restore = _performLastPlayedMiniPlayerRestore(userId: userId, generation: generation);
+    _lastPlayedMiniPlayerRestoreUserId = userId;
+    _lastPlayedMiniPlayerRestoreActiveGeneration = generation;
+    _lastPlayedMiniPlayerRestoreFuture = restore;
+
+    try {
+      await restore;
+    } finally {
+      if (identical(_lastPlayedMiniPlayerRestoreFuture, restore)) {
+        _lastPlayedMiniPlayerRestoreFuture = null;
+        _lastPlayedMiniPlayerRestoreUserId = null;
+        _lastPlayedMiniPlayerRestoreActiveGeneration = null;
+      }
+    }
+  }
+
+  Future<void> _performLastPlayedMiniPlayerRestore({required String userId, required int generation}) async {
+    final lastPlayedItem = await _readLastPlayedQueueItemForActiveUser(explicitUserId: userId);
     if (lastPlayedItem == null) {
       return;
     }
 
-    _lastQueueItem = lastPlayedItem;
-
-    final rawSnapshot = await _readLastPlayedMiniPlayerSnapshotRawForActiveUser(explicitUserId: explicitUserId);
+    final rawSnapshot = await _readLastPlayedMiniPlayerSnapshotRawForActiveUser(explicitUserId: userId);
     final snapshot = LastPlayedMiniPlayerSnapshot.fromRawJson(rawSnapshot);
     if (snapshot == null) {
+      return;
+    }
+
+    final progress = await _ref
+        .read(mediaProgressProvider.notifier)
+        .fetchOrRefreshIndividualProgress(lastPlayedItem.itemId, episodeId: lastPlayedItem.episodeId, userId: userId);
+
+    if (!_canPublishLastPlayedMiniPlayerRestore(userId: userId, generation: generation)) {
       return;
     }
 
@@ -156,13 +212,6 @@ extension _BGAudioHandlerResume on BGAudioHandler {
     final isEnabled = _ref
         .read(settingsManagerProvider.notifier)
         .getGlobalSetting<bool>(SettingKeys.showLastPlayedMiniPlayerAlways);
-    if (isEnabled) {
-      _setLastPlayedMiniPlayerSnapshot(finalSnapshot);
-    }
-
-    final progress = await _ref
-        .read(mediaProgressProvider.notifier)
-        .fetchOrRefreshIndividualProgress(lastPlayedItem.itemId, episodeId: lastPlayedItem.episodeId);
 
     final resumePosition = progress != null
         ? Duration(microseconds: (progress.currentTime * Duration.microsecondsPerSecond).round())
@@ -171,6 +220,7 @@ extension _BGAudioHandlerResume on BGAudioHandler {
         ? Duration(microseconds: (progress.duration * Duration.microsecondsPerSecond).round())
         : Duration.zero;
 
+    _lastQueueItem = lastPlayedItem;
     _restoredPosition = resumePosition;
     _restoredMediaItem = MediaItem(
       id: finalSnapshot.episodeId ?? finalSnapshot.itemId,
@@ -183,11 +233,20 @@ extension _BGAudioHandlerResume on BGAudioHandler {
       isLive: false,
       artUri: finalSnapshot.cover,
     );
+    _setLastPlayedMiniPlayerSnapshot(isEnabled ? finalSnapshot : null);
 
-    if (_currentMediaItem == null) {
-      mediaItem.add(_restoredMediaItem);
-      unawaited(_updatePlaybackState());
-    }
+    mediaItem.add(_restoredMediaItem);
+    unawaited(_updatePlaybackState());
+  }
+
+  bool _canPublishLastPlayedMiniPlayerRestore({required String userId, required int generation}) {
+    final observedUserId = _observedActiveUserId;
+    return !_isDisposing &&
+        generation == _lastPlayedMiniPlayerRestoreGeneration &&
+        (observedUserId == null || observedUserId == userId) &&
+        _currentMediaItem == null &&
+        queueList.isEmpty &&
+        !_queueTransitionLoading;
   }
 
   Future<QueueItem?> _readLastPlayedQueueItemForActiveUser({String? explicitUserId}) async {


### PR DESCRIPTION
## Summary

Fixes issues where cold boots (either via widget or auto-resume) [In theory also media notification. But on most Android versions/different OEM, I *think* it should be shown as inactive, if the actual app was suspended]

## Platforms Affected

<!-- The selected platforms are built and tested by CI. Select all platforms affected by this PR. Keep the checkbox labels unchanged so CI can parse them. You can check the box with [x] or leave it unchecked with [ ]. -->

- [ ] Linux
- [ ] Windows
- [x] Android (and Android Auto)
- [ ] iOS
- [ ] macOS
- [ ] Android Automotive
- [ ] Wear OS

## Additional Notes

<!-- Add reviewer context, screenshots, migration notes, or follow-up tasks. -->
