### PR TITLE
Add support for new ABS endpoints

### DIFF
--- a/lib/api/me/bookmarks_response.dart
+++ b/lib/api/me/bookmarks_response.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:yaabsa/api/me/bookmark.dart';
+
+part 'bookmarks_response.freezed.dart';
+part 'bookmarks_response.g.dart';
+
+@freezed
+abstract class BookmarksResponse with _$BookmarksResponse {
+  const factory BookmarksResponse({@JsonKey(name: 'bookmarks') @Default(<Bookmark>[]) List<Bookmark> bookmarks}) =
+      _BookmarksResponse;
+
+  factory BookmarksResponse.fromJson(Map<String, dynamic> json) => _$BookmarksResponseFromJson(json);
+}

--- a/lib/api/me/bookmarks_response.freezed.dart
+++ b/lib/api/me/bookmarks_response.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'bookmarks_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BookmarksResponse {
+
+@JsonKey(name: 'bookmarks') List<Bookmark> get bookmarks;
+/// Create a copy of BookmarksResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BookmarksResponseCopyWith<BookmarksResponse> get copyWith => _$BookmarksResponseCopyWithImpl<BookmarksResponse>(this as BookmarksResponse, _$identity);
+
+  /// Serializes this BookmarksResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BookmarksResponse&&const DeepCollectionEquality().equals(other.bookmarks, bookmarks));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(bookmarks));
+
+@override
+String toString() {
+  return 'BookmarksResponse(bookmarks: $bookmarks)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BookmarksResponseCopyWith<$Res>  {
+  factory $BookmarksResponseCopyWith(BookmarksResponse value, $Res Function(BookmarksResponse) _then) = _$BookmarksResponseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'bookmarks') List<Bookmark> bookmarks
+});
+
+
+
+
+}
+/// @nodoc
+class _$BookmarksResponseCopyWithImpl<$Res>
+    implements $BookmarksResponseCopyWith<$Res> {
+  _$BookmarksResponseCopyWithImpl(this._self, this._then);
+
+  final BookmarksResponse _self;
+  final $Res Function(BookmarksResponse) _then;
+
+/// Create a copy of BookmarksResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? bookmarks = null,}) {
+  return _then(_self.copyWith(
+bookmarks: null == bookmarks ? _self.bookmarks : bookmarks // ignore: cast_nullable_to_non_nullable
+as List<Bookmark>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BookmarksResponse].
+extension BookmarksResponsePatterns on BookmarksResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BookmarksResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BookmarksResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BookmarksResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _BookmarksResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BookmarksResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BookmarksResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'bookmarks')  List<Bookmark> bookmarks)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BookmarksResponse() when $default != null:
+return $default(_that.bookmarks);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'bookmarks')  List<Bookmark> bookmarks)  $default,) {final _that = this;
+switch (_that) {
+case _BookmarksResponse():
+return $default(_that.bookmarks);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'bookmarks')  List<Bookmark> bookmarks)?  $default,) {final _that = this;
+switch (_that) {
+case _BookmarksResponse() when $default != null:
+return $default(_that.bookmarks);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _BookmarksResponse implements BookmarksResponse {
+  const _BookmarksResponse({@JsonKey(name: 'bookmarks') final  List<Bookmark> bookmarks = const <Bookmark>[]}): _bookmarks = bookmarks;
+  factory _BookmarksResponse.fromJson(Map<String, dynamic> json) => _$BookmarksResponseFromJson(json);
+
+ final  List<Bookmark> _bookmarks;
+@override@JsonKey(name: 'bookmarks') List<Bookmark> get bookmarks {
+  if (_bookmarks is EqualUnmodifiableListView) return _bookmarks;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_bookmarks);
+}
+
+
+/// Create a copy of BookmarksResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BookmarksResponseCopyWith<_BookmarksResponse> get copyWith => __$BookmarksResponseCopyWithImpl<_BookmarksResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BookmarksResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BookmarksResponse&&const DeepCollectionEquality().equals(other._bookmarks, _bookmarks));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_bookmarks));
+
+@override
+String toString() {
+  return 'BookmarksResponse(bookmarks: $bookmarks)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BookmarksResponseCopyWith<$Res> implements $BookmarksResponseCopyWith<$Res> {
+  factory _$BookmarksResponseCopyWith(_BookmarksResponse value, $Res Function(_BookmarksResponse) _then) = __$BookmarksResponseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'bookmarks') List<Bookmark> bookmarks
+});
+
+
+
+
+}
+/// @nodoc
+class __$BookmarksResponseCopyWithImpl<$Res>
+    implements _$BookmarksResponseCopyWith<$Res> {
+  __$BookmarksResponseCopyWithImpl(this._self, this._then);
+
+  final _BookmarksResponse _self;
+  final $Res Function(_BookmarksResponse) _then;
+
+/// Create a copy of BookmarksResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? bookmarks = null,}) {
+  return _then(_BookmarksResponse(
+bookmarks: null == bookmarks ? _self._bookmarks : bookmarks // ignore: cast_nullable_to_non_nullable
+as List<Bookmark>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/me/bookmarks_response.g.dart
+++ b/lib/api/me/bookmarks_response.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bookmarks_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BookmarksResponse _$BookmarksResponseFromJson(Map<String, dynamic> json) => _BookmarksResponse(
+  bookmarks:
+      (json['bookmarks'] as List<dynamic>?)?.map((e) => Bookmark.fromJson(e as Map<String, dynamic>)).toList() ??
+      const <Bookmark>[],
+);
+
+Map<String, dynamic> _$BookmarksResponseToJson(_BookmarksResponse instance) => <String, dynamic>{
+  'bookmarks': instance.bookmarks,
+};

--- a/lib/api/me/media_progress_response.dart
+++ b/lib/api/me/media_progress_response.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:yaabsa/api/me/media_progress.dart';
+
+part 'media_progress_response.freezed.dart';
+part 'media_progress_response.g.dart';
+
+@freezed
+abstract class MediaProgressResponse with _$MediaProgressResponse {
+  const factory MediaProgressResponse({
+    @JsonKey(name: 'mediaProgress') @Default(<MediaProgress>[]) List<MediaProgress> mediaProgress,
+  }) = _MediaProgressResponse;
+
+  factory MediaProgressResponse.fromJson(Map<String, dynamic> json) => _$MediaProgressResponseFromJson(json);
+}

--- a/lib/api/me/media_progress_response.freezed.dart
+++ b/lib/api/me/media_progress_response.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'media_progress_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MediaProgressResponse {
+
+@JsonKey(name: 'mediaProgress') List<MediaProgress> get mediaProgress;
+/// Create a copy of MediaProgressResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MediaProgressResponseCopyWith<MediaProgressResponse> get copyWith => _$MediaProgressResponseCopyWithImpl<MediaProgressResponse>(this as MediaProgressResponse, _$identity);
+
+  /// Serializes this MediaProgressResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MediaProgressResponse&&const DeepCollectionEquality().equals(other.mediaProgress, mediaProgress));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(mediaProgress));
+
+@override
+String toString() {
+  return 'MediaProgressResponse(mediaProgress: $mediaProgress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MediaProgressResponseCopyWith<$Res>  {
+  factory $MediaProgressResponseCopyWith(MediaProgressResponse value, $Res Function(MediaProgressResponse) _then) = _$MediaProgressResponseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'mediaProgress') List<MediaProgress> mediaProgress
+});
+
+
+
+
+}
+/// @nodoc
+class _$MediaProgressResponseCopyWithImpl<$Res>
+    implements $MediaProgressResponseCopyWith<$Res> {
+  _$MediaProgressResponseCopyWithImpl(this._self, this._then);
+
+  final MediaProgressResponse _self;
+  final $Res Function(MediaProgressResponse) _then;
+
+/// Create a copy of MediaProgressResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mediaProgress = null,}) {
+  return _then(_self.copyWith(
+mediaProgress: null == mediaProgress ? _self.mediaProgress : mediaProgress // ignore: cast_nullable_to_non_nullable
+as List<MediaProgress>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MediaProgressResponse].
+extension MediaProgressResponsePatterns on MediaProgressResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MediaProgressResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MediaProgressResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MediaProgressResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _MediaProgressResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MediaProgressResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MediaProgressResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'mediaProgress')  List<MediaProgress> mediaProgress)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MediaProgressResponse() when $default != null:
+return $default(_that.mediaProgress);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'mediaProgress')  List<MediaProgress> mediaProgress)  $default,) {final _that = this;
+switch (_that) {
+case _MediaProgressResponse():
+return $default(_that.mediaProgress);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'mediaProgress')  List<MediaProgress> mediaProgress)?  $default,) {final _that = this;
+switch (_that) {
+case _MediaProgressResponse() when $default != null:
+return $default(_that.mediaProgress);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _MediaProgressResponse implements MediaProgressResponse {
+  const _MediaProgressResponse({@JsonKey(name: 'mediaProgress') final  List<MediaProgress> mediaProgress = const <MediaProgress>[]}): _mediaProgress = mediaProgress;
+  factory _MediaProgressResponse.fromJson(Map<String, dynamic> json) => _$MediaProgressResponseFromJson(json);
+
+ final  List<MediaProgress> _mediaProgress;
+@override@JsonKey(name: 'mediaProgress') List<MediaProgress> get mediaProgress {
+  if (_mediaProgress is EqualUnmodifiableListView) return _mediaProgress;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_mediaProgress);
+}
+
+
+/// Create a copy of MediaProgressResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MediaProgressResponseCopyWith<_MediaProgressResponse> get copyWith => __$MediaProgressResponseCopyWithImpl<_MediaProgressResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$MediaProgressResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MediaProgressResponse&&const DeepCollectionEquality().equals(other._mediaProgress, _mediaProgress));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_mediaProgress));
+
+@override
+String toString() {
+  return 'MediaProgressResponse(mediaProgress: $mediaProgress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MediaProgressResponseCopyWith<$Res> implements $MediaProgressResponseCopyWith<$Res> {
+  factory _$MediaProgressResponseCopyWith(_MediaProgressResponse value, $Res Function(_MediaProgressResponse) _then) = __$MediaProgressResponseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'mediaProgress') List<MediaProgress> mediaProgress
+});
+
+
+
+
+}
+/// @nodoc
+class __$MediaProgressResponseCopyWithImpl<$Res>
+    implements _$MediaProgressResponseCopyWith<$Res> {
+  __$MediaProgressResponseCopyWithImpl(this._self, this._then);
+
+  final _MediaProgressResponse _self;
+  final $Res Function(_MediaProgressResponse) _then;
+
+/// Create a copy of MediaProgressResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mediaProgress = null,}) {
+  return _then(_MediaProgressResponse(
+mediaProgress: null == mediaProgress ? _self._mediaProgress : mediaProgress // ignore: cast_nullable_to_non_nullable
+as List<MediaProgress>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/me/media_progress_response.g.dart
+++ b/lib/api/me/media_progress_response.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'media_progress_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_MediaProgressResponse _$MediaProgressResponseFromJson(Map<String, dynamic> json) => _MediaProgressResponse(
+  mediaProgress:
+      (json['mediaProgress'] as List<dynamic>?)
+          ?.map((e) => MediaProgress.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <MediaProgress>[],
+);
+
+Map<String, dynamic> _$MediaProgressResponseToJson(_MediaProgressResponse instance) => <String, dynamic>{
+  'mediaProgress': instance.mediaProgress,
+};

--- a/lib/api/routes/me_api.dart
+++ b/lib/api/routes/me_api.dart
@@ -2,8 +2,10 @@ import 'package:yaabsa/api/library/stats/listening_sessions_page.dart';
 import 'package:yaabsa/api/library/stats/user_listening_stats.dart';
 import 'package:yaabsa/api/library/stats/year_in_review_stats.dart';
 import 'package:yaabsa/api/me/bookmark.dart';
+import 'package:yaabsa/api/me/bookmarks_response.dart';
 import 'package:yaabsa/api/me/login.dart';
 import 'package:yaabsa/api/me/media_progress.dart';
+import 'package:yaabsa/api/me/media_progress_response.dart';
 import 'package:yaabsa/api/me/request/create_bookmark_request.dart';
 import 'package:yaabsa/api/me/request/login_request.dart';
 import 'package:yaabsa/api/me/status.dart';
@@ -147,6 +149,55 @@ class MeApi {
     return ABSApi.makeApiGetRequest(
       route: '/api/me',
       fromJson: (data) => User.fromJson(data),
+      cancelToken: cancelToken,
+      headers: headers,
+      extra: extra,
+      dio: _dio,
+      queryParams: {},
+    );
+  }
+
+  Future<Response<MediaProgressResponse>> getAllMediaProgress({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+  }) async {
+    return ABSApi.makeApiGetRequest(
+      route: '/api/me/progress',
+      fromJson: (data) => MediaProgressResponse.fromJson(data as Map<String, dynamic>),
+      cancelToken: cancelToken,
+      headers: headers,
+      extra: extra,
+      dio: _dio,
+      queryParams: {},
+    );
+  }
+
+  Future<Response<BookmarksResponse>> getAllBookmarks({
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+  }) async {
+    return ABSApi.makeApiGetRequest(
+      route: '/api/me/bookmarks',
+      fromJson: (data) => BookmarksResponse.fromJson(data as Map<String, dynamic>),
+      cancelToken: cancelToken,
+      headers: headers,
+      extra: extra,
+      dio: _dio,
+      queryParams: {},
+    );
+  }
+
+  Future<Response<BookmarksResponse>> getBookmarksForLibraryItem(
+    String libraryItemId, {
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+  }) async {
+    return ABSApi.makeApiGetRequest(
+      route: '/api/me/bookmarks/$libraryItemId',
+      fromJson: (data) => BookmarksResponse.fromJson(data as Map<String, dynamic>),
       cancelToken: cancelToken,
       headers: headers,
       extra: extra,

--- a/lib/provider/common/media_progress_provider.dart
+++ b/lib/provider/common/media_progress_provider.dart
@@ -4,9 +4,11 @@ import 'dart:convert';
 import 'package:yaabsa/api/library_items/playback_session.dart';
 import 'package:yaabsa/api/me/media_progress.dart';
 import 'package:yaabsa/api/me/media_item_type.dart';
+import 'package:yaabsa/api/routes/abs_api.dart';
 import 'package:yaabsa/database/app_database.dart';
 import 'package:yaabsa/provider/core/user_providers.dart';
 import 'package:yaabsa/util/logger.dart';
+import 'package:yaabsa/util/server_version.dart';
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -216,6 +218,21 @@ class MediaProgressNotifier extends _$MediaProgressNotifier {
     }
   }
 
+  Future<List<MediaProgress>> _fetchAllRemoteProgress(ABSApi absApi) async {
+    final meApi = absApi.getMeApi();
+
+    if (!serverSupportsMediaProgressAndBookmarkRoutes(ref.read(serverVersionProvider))) {
+      return (await meApi.getUser()).data?.mediaProgress ?? const <MediaProgress>[];
+    }
+
+    final response = await meApi.getAllMediaProgress();
+    final progressResponse = response.data;
+    if (progressResponse == null) {
+      throw Exception('Media progress response is null.');
+    }
+    return progressResponse.mediaProgress;
+  }
+
   @override
   Future<Map<String, MediaProgress>> build() async {
     final userId = _activeUserId();
@@ -237,14 +254,8 @@ class MediaProgressNotifier extends _$MediaProgressNotifier {
     }
 
     try {
-      final meApi = absApi.getMeApi();
-      final userResponse = await meApi.getUser();
-      final user = userResponse.data;
-      if (user == null) {
-        throw Exception('User data is null, cannot fetch media progress.');
-      }
-
-      final remoteMap = _listToMap(user.mediaProgress);
+      final remoteProgress = await _fetchAllRemoteProgress(absApi);
+      final remoteMap = _listToMap(remoteProgress);
       final mergedMap = _mergeProgressMaps(localMap, remoteMap);
       state = AsyncData(mergedMap);
       await _persistProgressList(remoteMap.values);
@@ -282,14 +293,8 @@ class MediaProgressNotifier extends _$MediaProgressNotifier {
     }
 
     try {
-      final meApi = absApi.getMeApi();
-      final userResponse = await meApi.getUser();
-      final user = userResponse.data;
-      if (user == null) {
-        throw Exception('User data is null during refresh all progress.');
-      }
-
-      final remoteMap = _listToMap(user.mediaProgress);
+      final remoteProgress = await _fetchAllRemoteProgress(absApi);
+      final remoteMap = _listToMap(remoteProgress);
       final mergedMap = _mergeProgressMaps(baseMap, remoteMap);
       state = AsyncData(mergedMap);
       await _persistProgressList(remoteMap.values);

--- a/lib/provider/common/media_progress_provider.g.dart
+++ b/lib/provider/common/media_progress_provider.g.dart
@@ -33,7 +33,7 @@ final class MediaProgressNotifierProvider
   MediaProgressNotifier create() => MediaProgressNotifier();
 }
 
-String _$mediaProgressNotifierHash() => r'a235a64e702895753e4a22db68b2230976ac2120';
+String _$mediaProgressNotifierHash() => r'5f47250ff27c54b0c25c57b3834699fa6a0057b9';
 
 abstract class _$MediaProgressNotifier extends $AsyncNotifier<Map<String, MediaProgress>> {
   FutureOr<Map<String, MediaProgress>> build();

--- a/lib/provider/core/user_providers.dart
+++ b/lib/provider/core/user_providers.dart
@@ -90,6 +90,10 @@ bool _shouldEmitRefreshedUser({required User previous, required User next}) {
     return true;
   }
 
+  if (previous.setting?.version != next.setting?.version) {
+    return true;
+  }
+
   return false;
 }
 
@@ -297,4 +301,9 @@ ABSApi? absApi(Ref ref) {
   }
 
   return api;
+}
+
+@Riverpod(keepAlive: true)
+String? serverVersion(Ref ref) {
+  return ref.watch(currentUserProvider).value?.setting?.version;
 }

--- a/lib/provider/core/user_providers.g.dart
+++ b/lib/provider/core/user_providers.g.dart
@@ -141,3 +141,38 @@ final class AbsApiProvider extends $FunctionalProvider<ABSApi?, ABSApi?, ABSApi?
 }
 
 String _$absApiHash() => r'7563d39bd28618fe2fba1a2096df1d9bd5d8b88b';
+
+@ProviderFor(serverVersion)
+final serverVersionProvider = ServerVersionProvider._();
+
+final class ServerVersionProvider extends $FunctionalProvider<String?, String?, String?> with $Provider<String?> {
+  ServerVersionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'serverVersionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$serverVersionHash();
+
+  @$internal
+  @override
+  $ProviderElement<String?> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+
+  @override
+  String? create(Ref ref) {
+    return serverVersion(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String? value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<String?>(value));
+  }
+}
+
+String _$serverVersionHash() => r'0873e2a00df334387ca983ec63225485b2c41d51';

--- a/lib/provider/player/user_bookmarks_provider.dart
+++ b/lib/provider/player/user_bookmarks_provider.dart
@@ -5,6 +5,7 @@ import 'package:yaabsa/database/app_database.dart';
 import 'package:yaabsa/provider/core/server_reachability_provider.dart';
 import 'package:yaabsa/provider/core/user_providers.dart';
 import 'package:yaabsa/util/logger.dart';
+import 'package:yaabsa/util/server_version.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_bookmarks_provider.g.dart';
@@ -215,8 +216,10 @@ class UserBookmarksNotifier extends _$UserBookmarksNotifier {
       return merged;
     }
 
-    final response = await api.getMeApi().getUser();
-    final remoteBookmarks = response.data?.bookmarks ?? const <Bookmark>[];
+    final remoteBookmarks = serverSupportsMediaProgressAndBookmarkRoutes(ref.read(serverVersionProvider))
+        ? (await api.getMeApi().getAllBookmarks()).data?.bookmarks ?? const <Bookmark>[]
+        : (await api.getMeApi().getUser()).data?.bookmarks ?? const <Bookmark>[];
+
     final merged = _applyPendingMutations(remoteBookmarks, pendingEntries);
     state = AsyncData(merged);
     return merged;

--- a/lib/provider/player/user_bookmarks_provider.g.dart
+++ b/lib/provider/player/user_bookmarks_provider.g.dart
@@ -32,7 +32,7 @@ final class UserBookmarksNotifierProvider extends $AsyncNotifierProvider<UserBoo
   UserBookmarksNotifier create() => UserBookmarksNotifier();
 }
 
-String _$userBookmarksNotifierHash() => r'c3c3c1d70845ac5694b9236e0e3b8294fa6ed3f2';
+String _$userBookmarksNotifierHash() => r'4b9056eed84af918708e8b9536e9c509e19e5512';
 
 abstract class _$UserBookmarksNotifier extends $AsyncNotifier<List<Bookmark>> {
   FutureOr<List<Bookmark>> build();

--- a/lib/screens/reader/reader.dart
+++ b/lib/screens/reader/reader.dart
@@ -39,6 +39,7 @@ import 'package:yaabsa/screens/settings/reader_tts_settings.dart';
 import 'package:yaabsa/screens/reader/widgets/reader_pdf_view.dart';
 import 'package:yaabsa/util/logger.dart';
 import 'package:yaabsa/util/network/request_headers.dart';
+import 'package:yaabsa/util/server_version.dart';
 import 'package:yaabsa/util/setting_key.dart';
 
 part 'reader_annotation_actions.dart';

--- a/lib/screens/reader/reader_core_helpers.dart
+++ b/lib/screens/reader/reader_core_helpers.dart
@@ -127,8 +127,16 @@ extension _ReaderCoreHelpers on _ReaderState {
       throw Exception('API not available');
     }
 
-    final userResponse = await api.getMeApi().getUser();
-    return userResponse.data?.bookmarks ?? const <Bookmark>[];
+    if (!serverSupportsMediaProgressAndBookmarkRoutes(ref.read(serverVersionProvider))) {
+      final userResponse = await api.getMeApi().getUser();
+      return userResponse.data?.bookmarks
+              ?.where((bookmark) => bookmark.libraryItemId == widget.itemId)
+              .toList(growable: false) ??
+          const <Bookmark>[];
+    }
+
+    final bookmarksResponse = await api.getMeApi().getBookmarksForLibraryItem(widget.itemId);
+    return bookmarksResponse.data?.bookmarks ?? const <Bookmark>[];
   }
 
   void _scheduleAutoAnnotationSync({required bool isEpubMode}) {

--- a/lib/screens/wear/wear_player_screen.dart
+++ b/lib/screens/wear/wear_player_screen.dart
@@ -5,6 +5,7 @@ import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaabsa/api/me/media_progress.dart';
+import 'package:yaabsa/api/routes/abs_api.dart';
 import 'package:yaabsa/database/app_database.dart';
 import 'package:yaabsa/main_wear.dart' show wearAudioHandler;
 import 'package:yaabsa/models/internal_media.dart';
@@ -16,6 +17,7 @@ import 'package:yaabsa/provider/player/session_provider.dart';
 import 'package:yaabsa/screens/wear/components/wear_volume_control.dart';
 import 'package:yaabsa/util/audio_handler/wear_audio_handler.dart';
 import 'package:yaabsa/util/globals.dart' show downloadHandler;
+import 'package:yaabsa/util/server_version.dart';
 
 class WearPlayerScreen extends ConsumerStatefulWidget {
   const WearPlayerScreen({super.key});
@@ -115,7 +117,7 @@ class _WearPlayerScreenState extends ConsumerState<WearPlayerScreen> {
     final api = ref.read(absApiProvider);
     if (api == null) return;
     try {
-      final mp = (await api.getMeApi().getUser()).data?.mediaProgress;
+      final mp = await _fetchAllProgress(api);
       if (mp == null || mp.isEmpty) return;
       final sorted = [...mp]..sort((a, b) => (b.lastUpdate ?? 0).compareTo(a.lastUpdate ?? 0));
       final newest = sorted.firstWhere((p) => !p.isFinished, orElse: () => sorted.first);
@@ -123,6 +125,14 @@ class _WearPlayerScreenState extends ConsumerState<WearPlayerScreen> {
     } catch (_) {
       // Offline or transient failure; the next resume or socket event retries.
     }
+  }
+
+  Future<List<MediaProgress>?> _fetchAllProgress(ABSApi api) async {
+    if (!serverSupportsMediaProgressAndBookmarkRoutes(ref.read(serverVersionProvider))) {
+      return (await api.getMeApi().getUser()).data?.mediaProgress;
+    }
+
+    return (await api.getMeApi().getAllMediaProgress()).data?.mediaProgress;
   }
 
   void _stopDownloadIndicator() {
@@ -165,7 +175,7 @@ class _WearPlayerScreenState extends ConsumerState<WearPlayerScreen> {
       var freshProgress = false;
       if (api != null) {
         try {
-          mp = (await api.getMeApi().getUser()).data?.mediaProgress;
+          mp = await _fetchAllProgress(api);
           freshProgress = mp != null;
         } catch (_) {
           // Server unreachable; fall back to the progress cached with the

--- a/lib/util/server_version.dart
+++ b/lib/util/server_version.dart
@@ -1,0 +1,22 @@
+bool serverVersionAtLeast(String? version, {required int major, required int minor, int patch = 0}) {
+  final match = RegExp(r'^\s*v?(\d+)\.(\d+)(?:\.(\d+))?').firstMatch(version ?? '');
+  if (match == null) {
+    return false;
+  }
+
+  final currentMajor = int.parse(match.group(1)!);
+  final currentMinor = int.parse(match.group(2)!);
+  final currentPatch = int.tryParse(match.group(3) ?? '') ?? 0;
+
+  if (currentMajor != major) {
+    return currentMajor > major;
+  }
+  if (currentMinor != minor) {
+    return currentMinor > minor;
+  }
+  return currentPatch >= patch;
+}
+
+bool serverSupportsMediaProgressAndBookmarkRoutes(String? version) {
+  return serverVersionAtLeast(version, major: 2, minor: 36);
+}


### PR DESCRIPTION
## Summary

Adds support for faster /progress, /bookmarks and especially for getting annotations for a specific ebook. These are only available when using ABS version 2.36.0 or later.
Before this, the app will still fallback to older routes. They will be deprecated after 1 year of ABS updates

## Platforms Affected

<!-- The selected platforms are built and tested by CI. Select all platforms affected by this PR. Keep the checkbox labels unchanged so CI can parse them. You can check the box with [x] or leave it unchecked with [ ]. -->

- [x] Linux
- [ ] Windows
- [ ] Android (and Android Auto)
- [ ] iOS
- [ ] macOS
- [ ] Android Automotive
- [ ] Wear OS

## Additional Notes

<!-- Add reviewer context, screenshots, migration notes, or follow-up tasks. -->
