### PR TITLE
fix(player): reconcile last-played progress after API init

### DIFF
--- a/lib/util/audio_handler/bg_audio_handler_resume.dart
+++ b/lib/util/audio_handler/bg_audio_handler_resume.dart
@@ -98,6 +98,22 @@ extension _BGAudioHandlerResume on BGAudioHandler {
       }
       _setQueueTransitionTargetItem(lastPlayedItem);
 
+      // Widget/auto-resume can reach this path before absApiProvider has seen
+      // the cached active user. Wait for that first user emission so an
+      // available server can participate in progress reconciliation before a
+      // stale local resume position becomes active playback state.
+      if (_ref.read(absApiProvider) == null) {
+        try {
+          await _ref.read(currentUserProvider.future);
+        } catch (e) {
+          logger(
+            'Failed to initialize the active user before last-played progress refresh: $e',
+            tag: 'AudioHandler',
+            level: InfoLevel.debug,
+          );
+        }
+      }
+
       final progress = await _ref
           .read(mediaProgressProvider.notifier)
           .fetchOrRefreshIndividualProgress(


### PR DESCRIPTION
## Summary

Fixes #139.

Widget Quick Play can cold-start `playLastPlayed()` before `absApiProvider` has seen the cached active user. In that state, `fetchOrRefreshIndividualProgress()` falls back to the local cache, so an old resume position can become active playback and later be synced back to Audiobookshelf.

This change waits for the first `currentUserProvider` emission when the ABS API is not initialized yet, then uses the existing progress refresh path. `SessionRepository.openSession()` already waits for the same user provider before reading `absApiProvider`; this moves that readiness point earlier, before the resume position is selected.

No progress conflict policy or playback-sync behavior is changed. If the API still cannot be initialized or the remote fetch fails, the existing local cached-progress fallback remains in place.

## Platforms Affected

- [ ] Linux
- [ ] Windows
- [x] Android (and Android Auto)
- [ ] iOS
- [ ] macOS
- [ ] Android Automotive
- [ ] Wear OS

## Additional Notes

The reported reproduction used Android home-screen Widget Quick Play after YAABSA had been closed for a while. The issue was reproduced on 1.10.1, and the same relevant call ordering is still present on current `master`.

The patch is intentionally limited to the last-played resume path: one production file, no new timestamp/furthest-position heuristics, and no changes to `PlaybackSyncService` or session synchronization.